### PR TITLE
add flash attention support in training to save memory and speed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ Download required NLTK data
     nltk.download('wordnet')
 ```
 
+Optional:
+
+Install flash attention (v2) if you are tight in GPU memory. Please refer to [flash attention's installation](https://github.com/Dao-AILab/flash-attention/tree/main#installation-and-features)
+
 ## Data & Model Preparation for Training
 - Data
     
@@ -532,4 +536,4 @@ The project is CC BY NC 4.0 (allowing only non-commercial use) and models traine
 ## Acknowledgement
 We thank [Hongxing Fan](https://scholar.google.com/citations?user=Wnk95ccAAAAJ), [Zeren Chen](https://github.com/Zx55) for support of LAMM project. 
 
-We also thanks the great works including [CLIP](https://github.com/openai/CLIP), [EPCL](https://arxiv.org/abs/2212.04098), [LLaMA](https://github.com/facebookresearch/llama), [Vicuna](https://github.com/lm-sys/FastChat)
+We also thanks the great works including [CLIP](https://github.com/openai/CLIP), [EPCL](https://arxiv.org/abs/2212.04098), [LLaMA](https://github.com/facebookresearch/llama), [Vicuna](https://github.com/lm-sys/FastChat), [FlashAttention](https://github.com/Dao-AILab/flash-attention/)

--- a/README.md
+++ b/README.md
@@ -239,7 +239,13 @@ Download required NLTK data
 
 Optional:
 
+- flash attention(v2)   
 Install flash attention (v2) if you are tight in GPU memory. Please refer to [flash attention's installation](https://github.com/Dao-AILab/flash-attention/tree/main#installation-and-features)
+    
+    > FlashAttention-2 currently supports Ampere, Ada, or Hopper GPUs (e.g., A100, RTX 3090, RTX 4090, H100).
+
+- xformers   
+Install xformers if you are tight in GPU memory and cannot use flash attention (e.g., using Nvidia v100). Please refer to [xformers's installation](https://github.com/facebookresearch/xformers#installing-xformers)
 
 ## Data & Model Preparation for Training
 - Data

--- a/src/config/train_ds3.yaml
+++ b/src/config/train_ds3.yaml
@@ -1,0 +1,102 @@
+models:
+  lamm:
+      model_name: LAMMModel
+      agent_name: DeepSpeedAgent
+      stage1_train_dataset: LAMMDataset
+      test_dataset: SelfInstructTestDataset
+  lamm_peft:
+      model_name: LAMMPEFTModel
+      agent_name: DeepSpeedAgent
+      stage1_train_dataset: LAMMDataset
+      test_dataset: SelfInstructTestDataset
+
+# ========= Global configuration ========== #
+logging_step: 5
+# ========= Global configuration ========== #
+
+# generation hyper-parameters
+max_len: 512
+penalty_alpha: 0.6
+top_k: 10
+top_p: 0.7
+random_prefix_len: 5
+sample_num: 2
+decoding_method: sampling
+generate_len: 512
+# some train configuration, more can be found under dsconfig folder
+seed: 0
+warmup_rate: 0.1
+epochs: 2
+max_length: 1024
+max_shard_size: 10GB
+
+# lora hyper-parameters
+lora_r: 32
+lora_alpha: 32
+lora_dropout: 0.1
+lora_target_modules: ['q_proj', 'k_proj', 'v_proj', 'o_proj']
+
+# deepspeed arguments
+deepspeed:
+  train_batch_size: 64
+  train_micro_batch_size_per_gpu: 2
+  gradient_accumulation_steps: 8
+  gradient_clipping: 1.0
+  steps_per_print: 1
+
+  zero_optimization:
+    stage: 3
+    contiguous_gradients: true
+    overlap_comm: true
+    contiguous_gradients: true
+    reduce_bucket_size: 5.0e+08
+    # reduce_bucket_size: auto
+    stage3_prefetch_bucket_size: 1.0e+08
+    # stage3_prefetch_bucket_size: auto
+    stage3_param_persistence_threshold: 5.0e+05
+    # stage3_param_persistence_threshold: auto
+    sub_group_size: 2.0e+08
+    stage3_max_live_parameters: 1.0e+08
+    stage3_max_reuse_distance: 1.0e+08
+    stage3_gather_16bit_weights_on_model_save: true
+    offload_optimizer:
+      device: cpu
+      pin_memory: true
+    offload_param:
+      device: cpu
+      pin_memory: true
+
+
+  optimizer:
+    type: Adam
+    params:
+      betas:
+      - 0.9
+      - 0.95
+      eps: 1.0e-08
+      lr: 0.0005
+      weight_decay: 0.001
+    
+  scheduler:
+    type: WarmupDecayLR
+    params:
+      total_num_steps: 20000
+      warmup_max_lr: 0.0005
+      warmup_min_lr: 0
+      warmup_num_steps: 10
+
+  fp16:
+    enabled: true
+    min_loss_scale: 1
+    opt_level: O2
+  
+  bf16:
+    enable: false
+
+  activation_checkpointing:
+    partition_activations: true
+    cpu_checkpointing: true
+    contiguous_memory_optimization: false
+    number_checkpoints: null
+    synchronize_checkpoint_boundary: false
+    profile: false

--- a/src/model/flash_attn_patch.py
+++ b/src/model/flash_attn_patch.py
@@ -1,0 +1,134 @@
+""" 
+This code is based on https://github.com/lm-sys/FastChat/blob/main/fastchat/train/llama_flash_attn_monkey_patch.py.
+"""
+
+from typing import List, Optional, Tuple, Dict
+
+import logging
+import torch
+import transformers
+from .modeling_llama import (
+    apply_rotary_pos_emb,
+    LlamaModel,
+    LlamaAttention,
+)
+
+from einops import rearrange
+from flash_attn.flash_attn_interface import flash_attn_varlen_qkvpacked_func
+from flash_attn.bert_padding import unpad_input, pad_input
+
+
+
+def smart_tokenizer_and_embedding_resize(
+    special_tokens_dict: Dict,
+    tokenizer: transformers.PreTrainedTokenizer,
+    model: transformers.PreTrainedModel,
+):
+    """Resize tokenizer and embedding.
+
+    Note: This is the unoptimized version that may make your embedding size not be divisible by 64.
+    """
+    # TODO: padding embedding size for being divisible by 64.
+    num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict)
+    model.resize_token_embeddings(len(tokenizer))
+
+    if num_new_tokens > 0:
+        input_embeddings = model.get_input_embeddings().weight.data
+        output_embeddings = model.get_output_embeddings().weight.data
+
+        input_embeddings_avg = input_embeddings[:-num_new_tokens].mean(dim=0, keepdim=True)
+        output_embeddings_avg = output_embeddings[:-num_new_tokens].mean(dim=0, keepdim=True)
+
+        input_embeddings[-num_new_tokens:] = input_embeddings_avg
+        output_embeddings[-num_new_tokens:] = output_embeddings_avg
+
+
+def llama_flash_attn_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.Tensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor],
+            Optional[Tuple[torch.Tensor]]]:
+    """Input shape: Batch x Time x Channel
+
+    attention_mask: [bsz, q_len]
+    """
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states = self.q_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    key_states = self.k_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    value_states = self.v_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    # [bsz, q_len, nh, hd]
+    # [bsz, nh, q_len, hd]
+
+    kv_seq_len = key_states.shape[-2]
+    assert past_key_value is None, "past_key_value is not supported"
+
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+    # [bsz, nh, t, hd]
+    assert not output_attentions, "output_attentions is not supported"
+    assert not use_cache, "use_cache is not supported"
+
+    # Flash attention codes from
+    # https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attention.py
+
+    # transform the data into the format required by flash attention
+    qkv = torch.stack([query_states, key_states, value_states], dim=2) # [bsz, nh, 3, q_len, hd]
+    qkv = qkv.transpose(1, 3) # [bsz, q_len, 3, nh, hd]
+    # We have disabled _prepare_decoder_attention_mask in LlamaModel
+    # the attention_mask should be the same as the key_padding_mask
+    key_padding_mask = attention_mask
+
+
+    if key_padding_mask is None:
+        qkv = rearrange(qkv, 'b s ... -> (b s) ...')
+        max_s = q_len
+        cu_q_lens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32,
+                                device=qkv.device)
+        output = flash_attn_varlen_qkvpacked_func(
+            qkv, cu_q_lens, max_s, 0.0,
+            softmax_scale=None, causal=True
+        )
+        output = rearrange(output, '(b s) ... -> b s ...', b=bsz)
+    else:
+        nheads = qkv.shape[-2]
+        x = rearrange(qkv, 'b s three h d -> b s (three h d)')
+        x_unpad, indices, cu_q_lens, max_s = unpad_input(x, key_padding_mask)
+        x_unpad = rearrange(x_unpad, 'nnz (three h d) -> nnz three h d', three=3, h=nheads)
+        output_unpad = flash_attn_varlen_qkvpacked_func(
+            x_unpad, cu_q_lens, max_s, 0.0,
+            softmax_scale=None, causal=True
+        )
+        output = rearrange(pad_input(rearrange(output_unpad, 'nnz h d -> nnz (h d)'),
+                                    indices, bsz, q_len),
+                        'b s (h d) -> b s h d', h=nheads)
+    return self.o_proj(rearrange(output,
+                                    'b s h d -> b s (h d)')), None, None
+
+
+# Disable the transformation of the attention mask in LlamaModel as the flash attention
+# requires the attention mask to be the same as the key_padding_mask
+def _prepare_decoder_attention_mask(
+    self, attention_mask, input_shape, inputs_embeds, past_key_values_length
+):
+    # [bsz, seq_len]
+    return attention_mask
+
+
+def replace_llama_attn_with_flash_attn():
+    cuda_major, cuda_minor = torch.cuda.get_device_capability()
+    if cuda_major < 8:
+        logging.warning(
+            "Flash attention is only supported on A100 or H100 GPU during training due to head dim > 64 backward."
+            "ref: https://github.com/HazyResearch/flash-attention/issues/190#issuecomment-1523359593"
+        )
+    LlamaModel._prepare_decoder_attention_mask = (
+        _prepare_decoder_attention_mask
+    )
+    LlamaAttention.forward = llama_flash_attn_forward
+  

--- a/src/model/openlamm.py
+++ b/src/model/openlamm.py
@@ -278,6 +278,7 @@ class LAMMPEFTModel(nn.Module):
 
         self.max_tgt_len = args["max_tgt_len"]
         self.use_system = use_system
+        self.use_flash_attn = args['use_flash_attn']
         self.device = torch.cuda.current_device()
 
     def encode_image(self, image_paths):
@@ -534,6 +535,7 @@ class LAMMPEFTModel(nn.Module):
             attention_mask=attention_mask,
             return_dict=True,
             labels=targets,
+            use_cache=not self.use_flash_attn,
         )
         loss = outputs.loss
         # calculate the token accuarcy

--- a/src/model/openlamm.py
+++ b/src/model/openlamm.py
@@ -278,7 +278,8 @@ class LAMMPEFTModel(nn.Module):
 
         self.max_tgt_len = args["max_tgt_len"]
         self.use_system = use_system
-        self.use_flash_attn = getattr(args, 'use_flash_attn', False)
+        self.use_flash_attn = args.get('use_flash_attn', False)
+        self.use_xformers = args.get('use_xformers', False)
         self.device = torch.cuda.current_device()
 
     def encode_image(self, image_paths):

--- a/src/model/openlamm.py
+++ b/src/model/openlamm.py
@@ -278,7 +278,7 @@ class LAMMPEFTModel(nn.Module):
 
         self.max_tgt_len = args["max_tgt_len"]
         self.use_system = use_system
-        self.use_flash_attn = args['use_flash_attn']
+        self.use_flash_attn = getattr(args, 'use_flash_attn', False)
         self.device = torch.cuda.current_device()
 
     def encode_image(self, image_paths):

--- a/src/model/xformers_patch.py
+++ b/src/model/xformers_patch.py
@@ -1,0 +1,133 @@
+"""
+Directly copied the code from https://raw.githubusercontent.com/oobabooga/text-generation-webui/main/modules/llama_attn_hijack.py and made some adjustments
+"""
+
+import logging
+import math
+from typing import Optional, Tuple
+
+import torch
+from .modeling_llama import (
+    apply_rotary_pos_emb,
+    LlamaModel,
+    LlamaAttention,
+)
+from torch import nn
+
+try:
+    import xformers.ops
+except ImportError:
+    logging.error("xformers not found! Please install it before trying to use it.")
+
+
+def replace_llama_attn_with_xformers_attn():
+    LlamaAttention.forward = xformers_forward
+
+
+def xformers_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    # pylint: disable=duplicate-code
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states = (
+        self.q_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    key_states = (
+        self.k_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    value_states = (
+        self.v_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    (
+        query_states,
+        key_states,
+    ) = apply_rotary_pos_emb(
+        query_states, key_states, cos, sin, position_ids
+    )
+    # [bsz, nh, t, hd]
+
+    if past_key_value is not None:
+        # reuse k, v, self_attention
+        key_states = torch.cat([past_key_value[0], key_states], dim=2)
+        value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+    past_key_value = (key_states, value_states) if use_cache else None
+
+    # We only apply xformers optimizations if we don't need to output the whole attention matrix
+    if not output_attentions:
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+        value_states = value_states.transpose(1, 2)
+
+        # This is a nasty hack. We know attention_mask in transformers is either LowerTriangular or all Zeros.
+        # We therefore check if one element in the upper triangular portion is zero. If it is, then the mask is all zeros.
+        if attention_mask is None or attention_mask[0, 0, 0, 1] == 0:
+            # input and output should be of form (bsz, q_len, num_heads, head_dim)
+            attn_output = xformers.ops.memory_efficient_attention(
+                query_states, key_states, value_states, attn_bias=None
+            )
+        else:
+            # input and output should be of form (bsz, q_len, num_heads, head_dim)
+            attn_output = xformers.ops.memory_efficient_attention(
+                query_states,
+                key_states,
+                value_states,
+                attn_bias=xformers.ops.LowerTriangularMask(),
+            )
+        attn_weights = None
+    else:
+        attn_weights = torch.matmul(
+            query_states, key_states.transpose(2, 3)
+        ) / math.sqrt(self.head_dim)
+
+        if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention weights should be of size {(bsz * self.num_heads, q_len, kv_seq_len)}, but is"
+                f" {attn_weights.size()}"
+            )
+
+        if attention_mask is not None:
+            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                )
+            attn_weights = attn_weights + attention_mask
+            attn_weights = torch.max(
+                attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min)
+            )
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(
+            attn_weights, dim=-1, dtype=torch.float32
+        ).to(query_states.dtype)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2)
+
+    attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+    attn_output = self.o_proj(attn_output)
+    return attn_output, attn_weights, past_key_value

--- a/src/train.py
+++ b/src/train.py
@@ -109,6 +109,13 @@ def parser_args():
         default=40000,
         help="number of points in each point cloud",
     )
+    # flash attention
+    parser.add_argument(
+        "--use_flash_attn",
+        default=False,
+        action="store_true",
+        help="whether to use flash attention to speed up",
+    )
     args = parser.parse_args()
 
     if args.vision_feature_type == "local":
@@ -184,6 +191,11 @@ def main(**args):
             filename=f'{args["log_path"]}/train_{time.asctime()}.log',
             filemode="w",
         )
+    
+    if args['use_flash_attn']:
+        from model.flash_attn_patch import replace_llama_attn_with_flash_attn
+        logging.info("⚡⚡⚡ enable flash attention.")
+        replace_llama_attn_with_flash_attn()
 
     train_data, train_iter, sampler = load_lamm_dataset(args)
 

--- a/src/train.py
+++ b/src/train.py
@@ -116,7 +116,16 @@ def parser_args():
         action="store_true",
         help="whether to use flash attention to speed up",
     )
+    # xformers
+    parser.add_argument(
+        "--use_xformers",
+        default=False,
+        action="store_true",
+        help="whether to use xformers to speed up",
+    )
     args = parser.parse_args()
+
+    assert not (args.use_flash_attn and args.use_xformers), 'can only use one of flash attn and xformers.'
 
     if args.vision_feature_type == "local":
         args.num_vision_token = 256
@@ -196,6 +205,11 @@ def main(**args):
         from model.flash_attn_patch import replace_llama_attn_with_flash_attn
         logging.info("⚡⚡⚡ enable flash attention.")
         replace_llama_attn_with_flash_attn()
+
+    if args['use_xformers']:
+        from model.xformers_patch import replace_llama_attn_with_xformers_attn
+        logging.info("xxx enable xformers attention.")
+        replace_llama_attn_with_xformers_attn()
 
     train_data, train_iter, sampler = load_lamm_dataset(args)
 


### PR DESCRIPTION
1. add `src/model/flash_attn_patch.py`
2. add "--use_flash_attn" arg in train.py to replace `LlamaAttention.forward` and `LlamaModel._prepare_decoder_attention_mask`
3. when using flash attention, llama's `use_cache` should be `False`